### PR TITLE
Update tim.conf

### DIFF
--- a/tim.conf
+++ b/tim.conf
@@ -65,7 +65,9 @@ exten => s,n,playback(TIM/${VOICE}/${TimMins})       ; "45"
 exten => s,n,playback(TIM/${VOICE}/${TimSecs})       ; "and 30 seconds"
 exten => s,n,playback(TIM/${VOICE}/pips)             ; "pip, pip, pip"
 
-; And go back to the start of playback
-exten => s,n,GotoIf($[${EPOCH} >= ${MaxConnectTime}]?tim_hangup:tim_saytime)
+; And go back to the start of playback - delay if too soon
+exten => s,n,GotoIf($[${EPOCH} >= ${MaxConnectTime}]?tim_hangup:tim_replay)
+exten => s,n(tim_replay),GotoIf($[${EPOCH} >= ${SpeakTime}]?tim_saytime)
+exten => s,n,wait(1)
+exten => s,n,Goto(tim_replay)
 exten => s,n(tim_hangup),Hangup()
-


### PR DESCRIPTION
If the total time of the audio files isn't exactly ten seconds, the time will drift during a lengthy playback. If they are over ten seconds there isn't a practical way to correct the situation. However, if the length of the combined audio files is under ten seconds, once the slip from real time exceeds one second this change will automatically add a one-second pause to bring the announced time into sync with real time. This is the case with all of the audio samples I've tested. This will ensure that the time error on a lengthy playback doesn't exceed one second. 